### PR TITLE
修复 issue#92

### DIFF
--- a/lib/web-detector.js
+++ b/lib/web-detector.js
@@ -69,7 +69,7 @@ function WebParse (ua) {
     const mode = ieCore.engineMode;
 
     d.engine = {
-      name: name,
+      name: d.engine.name,
       version: ve,
       fullVersion: engineVersion,
       mode: parseFloat(mode),
@@ -87,7 +87,7 @@ function WebParse (ua) {
     const browserMode = ieCore.browserMode;
     const vb = parseFloat(browserVersion);
     d.browser = {
-      name: name,
+      name: d.browser.name,
       version: vb,
       fullVersion: browserVersion,
       mode: parseFloat(browserMode),


### PR DESCRIPTION
如题，在代码中发现 `name` 变量并没有声明，查阅了 v2.4.1 的代码发现 name 应该来自于 `detector.parse` 方法返回的变量中